### PR TITLE
change `cobaya-install -m` to `-p`

### DIFF
--- a/cobaya_files/readme_cobaya.md
+++ b/cobaya_files/readme_cobaya.md
@@ -8,7 +8,7 @@ Run the `spt3g_cobaya_install` script
 	
 	$> spt3g_cobaya_install /path/to/cobaya/packages [/path/to/clik]
 
-`/path/to/cobaya/packages/` is the path where the external code and packages for cobaya are installed. It's the path you gave when first installing the cobaya default cosmology files (using the command `cobaya-install cosmo -m /path/to/cobaya/packages`.
+`/path/to/cobaya/packages/` is the path where the external code and packages for cobaya are installed. It's the path you gave when first installing the cobaya default cosmology files (using the command `cobaya-install cosmo -p /path/to/cobaya/packages`.
 	
 `/path/to/clik` must point toward your install of the `clik` library from [https://github.com/benabed/clik](https://github.com/benabed/clik) and must be at least at version>=16.0. If not given, assumes that that cobaya already includes `clik` at version>=16.0.
 
@@ -23,7 +23,7 @@ Those steps are performed automatically by the install script.
 - Create a `spt_data` directory in `/path/to/cobaya/packages/data`
 - Move the `spt3g_Y1_v1_TTTEEE.clik` to `/path/to/cobaya/packages/data/spt_data`
 - Copy the `SPT3G_Y1` directory to `/path/to/cobaya/packages/code`
-- If your cobaya installation does not contains a version>=16.0 of `clik`(this is the case if you have installed the cobaya external default cosmology files with a `cobaya-install cosmo -m /path/to/cobaya/packages` for cobaya 3.2.1+), change the name of the directory `path/to/cobaya/packages/code/planck/` to  `path/to/cobaya/packages/code/planck_old/` 
+- If your cobaya installation does not contains a version>=16.0 of `clik`(this is the case if you have installed the cobaya external default cosmology files with a `cobaya-install cosmo -p /path/to/cobaya/packages` for cobaya 3.2.1+), change the name of the directory `path/to/cobaya/packages/code/planck/` to  `path/to/cobaya/packages/code/planck_old/` 
 - Create a link to your `clik` library installation (downloaded from [https://github.com/benabed/clik](https://github.com/benabed/clik)) to `path/to/cobaya/packages/code/planck/plc-3.1`.
 
 		$> ln -s /path/to/clik path/to/cobaya/packages/code/planck/plc-3.1


### PR DESCRIPTION
I think the option for the `cobaya-install` packages path is `-p`, not `-m`.